### PR TITLE
fix use of getBoundingClientRect in timetable/content

### DIFF
--- a/addon/components/as-calendar/timetable/content.js
+++ b/addon/components/as-calendar/timetable/content.js
@@ -1,26 +1,26 @@
-import { htmlSafe } from '@ember/template';
-import { computed } from '@ember/object';
-import { oneWay } from '@ember/object/computed';
-import Component from '@ember/component';
-import moment from 'moment';
+import { htmlSafe } from "@ember/template";
+import { computed } from "@ember/object";
+import { oneWay } from "@ember/object/computed";
+import Component from "@ember/component";
+import moment from "moment";
 
 export default Component.extend({
-  classNameBindings: [':as-calendar-timetable__content'],
-  attributeBindings: ['_style:style'],
+  classNameBindings: [":as-calendar-timetable__content"],
+  attributeBindings: ["_style:style"],
 
-  days: oneWay('model.days'),
+  days: oneWay("model.days"),
   model: null,
-  timeSlotDuration: oneWay('model.timeSlotDuration'),
-  timeSlots: oneWay('model.timeSlots'),
+  timeSlotDuration: oneWay("model.timeSlotDuration"),
+  timeSlots: oneWay("model.timeSlots"),
   timetable: null,
 
-  timeSlotStyle: computed('timeSlotHeight', function() {
-    return htmlSafe(`height: ${this.get('timeSlotHeight')}px`);
+  timeSlotStyle: computed("timeSlotHeight", function () {
+    return htmlSafe(`height: ${this.get("timeSlotHeight")}px`);
   }),
 
-  dayWidth: computed(function() {
-    if (this.get('_wasInserted')) {
-      return this.element.offsetWidth / this.get('days.length');
+  dayWidth: computed(function () {
+    if (this.get("_wasInserted")) {
+      return this.element.offsetWidth / this.get("days.length");
     } else {
       return 0;
     }
@@ -29,42 +29,55 @@ export default Component.extend({
   _wasInserted: false,
 
   _style: computed(
-  'model.isMonthView',
-  'timeSlotHeight',
-  'timeSlots.length', function() {
-      return htmlSafe(`height: ${this.get('model.isMonthView') ? '600px' : this.get('timeSlots.length') * this.get('timeSlotHeight')}px;`);
-  }),
+    "model.isMonthView",
+    "timeSlotHeight",
+    "timeSlots.length",
+    function () {
+      return htmlSafe(
+        `height: ${
+          this.get("model.isMonthView")
+            ? "600px"
+            : this.get("timeSlots.length") * this.get("timeSlotHeight")
+        }px;`
+      );
+    }
+  ),
 
   didInsertElement() {
-    this.set('_wasInserted', true);
+    this.set("_wasInserted", true);
   },
 
   init() {
     this._super(...arguments);
-    this.set('timetable.contentComponent', this);
+    this.set("timetable.contentComponent", this);
   },
 
   click(event) {
-    var offset = this.element.getBoundingClientRect();
+    var rect = this.element.getBoundingClientRect();
+    const offset = {
+      top: rect.top + window.pageYOffset,
+      left: rect.left + window.pageXOffset,
+    };
+
     var offsetX = event.pageX - Math.floor(offset.left);
     var offsetY = event.pageY - Math.floor(offset.top);
 
-    var dayIndex = Math.floor(offsetX / this.get('dayWidth'));
-    var timeSlotIndex = Math.floor(offsetY / this.get('timeSlotHeight'));
-    var day = this.get('days').objectAt(dayIndex);
+    var dayIndex = Math.floor(offsetX / this.get("dayWidth"));
+    var timeSlotIndex = Math.floor(offsetY / this.get("timeSlotHeight"));
+    var day = this.get("days").objectAt(dayIndex);
 
-    var timeSlot = this.get('timeSlots').objectAt(timeSlotIndex);
+    var timeSlot = this.get("timeSlots").objectAt(timeSlotIndex);
 
-    this.get('onSelectTime')(
-      moment(day.get('value')).add(timeSlot.get('time'))
+    this.get("onSelectTime")(
+      moment(day.get("value")).add(timeSlot.get("time"))
     );
   },
 
   actions: {
     goTo: function (day) {
-      if (this.get('onNavigateToDay')) {
-        this.get('onNavigateToDay')(day);
+      if (this.get("onNavigateToDay")) {
+        this.get("onNavigateToDay")(day);
       }
-    }
-  }
+    },
+  },
 });

--- a/addon/components/as-calendar/timetable/occurrence.js
+++ b/addon/components/as-calendar/timetable/occurrence.js
@@ -1,37 +1,37 @@
-import $ from 'jquery';
-import { run } from '@ember/runloop';
-import { oneWay } from '@ember/object/computed';
-import moment from 'moment';
-import interact from 'interactjs';
-import OccurrenceComponent from '../occurrence';
+import $ from "jquery";
+import { run } from "@ember/runloop";
+import { oneWay } from "@ember/object/computed";
+import moment from "moment";
+import interact from "interactjs";
+import OccurrenceComponent from "../occurrence";
 
 export default OccurrenceComponent.extend({
-  classNameBindings: [':as-calendar-occurrence--timetable'],
+  classNameBindings: [":as-calendar-occurrence--timetable"],
 
   timetable: null,
   isInteracting: false,
   isDraggable: true,
   isResizable: true,
   isRemovable: true,
-  dayWidth: oneWay('timetable.dayWidth'),
-  referenceElement: oneWay('timetable.referenceElement'),
+  dayWidth: oneWay("timetable.dayWidth"),
+  referenceElement: oneWay("timetable.referenceElement"),
   isEditable: true,
 
-  _calendar: oneWay('model.calendar'),
-  _dayEndingTime: oneWay('day.endingTime'),
+  _calendar: oneWay("model.calendar"),
+  _dayEndingTime: oneWay("day.endingTime"),
   _dragBottomDistance: null,
   _dragTopDistance: null,
   _dragVerticalOffset: null,
-  _preview: oneWay('_calendar.occurrencePreview'),
+  _preview: oneWay("_calendar.occurrencePreview"),
 
   didInsertElement() {
-    var interactable = interact(this.element).on('mouseup', (event) => {
+    var interactable = interact(this.element).on("mouseup", (event) => {
       run(this, this._mouseUp, event);
     });
 
-    if (this.get('isResizable')) {
+    if (this.get("isResizable")) {
       interactable.resizable({
-        edges: { bottom: '.as-calendar-occurrence__resize-handle' },
+        edges: { bottom: ".as-calendar-occurrence__resize-handle" },
 
         onstart: (event) => {
           run(this, this._resizeStart, event);
@@ -47,7 +47,7 @@ export default OccurrenceComponent.extend({
       });
     }
 
-    if (this.get('isDraggable')) {
+    if (this.get("isDraggable")) {
       interactable.draggable({
         onstart: (event) => {
           run(this, this._dragStart, event);
@@ -63,15 +63,17 @@ export default OccurrenceComponent.extend({
       });
     }
 
-    if (this.get('onClick')) {
-      interactable.on('tap', (event) => {
-        if (event.double) { return; }
+    if (this.get("onClick")) {
+      interactable.on("tap", (event) => {
+        if (event.double) {
+          return;
+        }
         run(this, this._tap, event);
       });
     }
 
-    if (this.get('onDoubleClick')) {
-      interactable.on('doubletap', (event) => {
+    if (this.get("onDoubleClick")) {
+      interactable.on("doubletap", (event) => {
         run(this, this._doubleTap, event);
       });
     }
@@ -81,78 +83,89 @@ export default OccurrenceComponent.extend({
     interact(this.element).off();
   },
 
-  _resizeStart: function() {
-    this.set('isInteracting', true);
-    this.set('_calendar.occurrencePreview', this.get('model').copy());
+  _resizeStart: function () {
+    this.set("isInteracting", true);
+    this.set("_calendar.occurrencePreview", this.get("model").copy());
   },
 
-  _resizeMove: function(event) {
+  _resizeMove: function (event) {
     var newDuration = moment.duration(
-      Math.floor(event.rect.height / this.get('timeSlotHeight')) *
-      this.get('computedTimeSlotDuration').as('ms')
+      Math.floor(event.rect.height / this.get("timeSlotHeight")) *
+        this.get("computedTimeSlotDuration").as("ms")
     );
 
     var changes = {
-      endsAt: moment(this.get('_startingTime')).add(newDuration).toDate()
+      endsAt: moment(this.get("_startingTime")).add(newDuration).toDate(),
     };
 
     this._validateAndSavePreview(changes);
   },
 
-  _resizeEnd: function() {
-    this.get('onUpdate')(this.get('content'), {
-      endsAt: this.get('_preview.content.endsAt')
+  _resizeEnd: function () {
+    this.get("onUpdate")(this.get("content"), {
+      endsAt: this.get("_preview.content.endsAt"),
     });
 
-    this.set('isInteracting', false);
-    this.set('_calendar.occurrencePreview', null);
+    this.set("isInteracting", false);
+    this.set("_calendar.occurrencePreview", null);
   },
 
-  _dragStart: function() {
+  _dragStart: function () {
     var $this = this.element;
-    var $referenceElement = this.get('referenceElement');
-    const preview = this.get('model').copy();
+    var $referenceElement = this.get("referenceElement");
+    const preview = this.get("model").copy();
 
-    preview.set('isPreview', true);
-    this.set('isInteracting', true);
-    this.set('_calendar.occurrencePreview', preview);
-    this.set('_dragVerticalOffset', 0);
-    this.set('_dragTopDistance', $referenceElement.getBoundingClientRect().top - $this.getBoundingClientRect().top);
+    preview.set("isPreview", true);
+    this.set("isInteracting", true);
+    this.set("_calendar.occurrencePreview", preview);
+    this.set("_dragVerticalOffset", 0);
+    // FIXME usage of getBoundingClientRect is incorrect
+    this.set(
+      "_dragTopDistance",
+      $referenceElement.getBoundingClientRect().top -
+        $this.getBoundingClientRect().top
+    );
 
-    this.set('_dragBottomDistance',
-             ($referenceElement.getBoundingClientRect().top + $referenceElement.offsetHeight) -
-      ($this.getBoundingClientRect().top + $this.offsetHeight));
+    this.set(
+      "_dragBottomDistance",
+      $referenceElement.getBoundingClientRect().top +
+        $referenceElement.offsetHeight -
+        ($this.getBoundingClientRect().top + $this.offsetHeight)
+    );
   },
 
-  _dragMove: function(event) {
-    this.set('_dragVerticalOffset', this.get('_dragVerticalOffset') + event.dy);
+  _dragMove: function (event) {
+    this.set("_dragVerticalOffset", this.get("_dragVerticalOffset") + event.dy);
 
     var dragTimeSlotOffset = this._dragTimeSlotOffset(event);
     var dragDayOffset = this._dragDayOffset(event);
-    var startsAt = moment(this.get('_startingTime')).add(dragTimeSlotOffset).add(dragDayOffset);
+    var startsAt = moment(this.get("_startingTime"))
+      .add(dragTimeSlotOffset)
+      .add(dragDayOffset);
 
     var changes = {
       startsAt: startsAt.toDate(),
-      endsAt: moment(startsAt).add(this.get('_duration')).toDate()
+      endsAt: moment(startsAt).add(this.get("_duration")).toDate(),
     };
 
     this._validateAndSavePreview(changes);
   },
 
-  _dragTimeSlotOffset: function() {
+  _dragTimeSlotOffset: function () {
     var verticalDrag = this._clamp(
-      this.get('_dragVerticalOffset'),
-      this.get('_dragTopDistance'),
-      this.get('_dragBottomDistance')
+      this.get("_dragVerticalOffset"),
+      this.get("_dragTopDistance"),
+      this.get("_dragBottomDistance")
     );
 
     return moment.duration(
-      Math.floor(verticalDrag / this.get('timeSlotHeight')) * this.get('computedTimeSlotDuration')
+      Math.floor(verticalDrag / this.get("timeSlotHeight")) *
+        this.get("computedTimeSlotDuration")
     );
   },
 
-  _dragDayOffset: function(event) {
-    var $referenceElement = $(this.get('referenceElement'));
+  _dragDayOffset: function (event) {
+    var $referenceElement = $(this.get("referenceElement"));
 
     var offsetX = this._clamp(
       event.pageX - $referenceElement.offset().left,
@@ -161,67 +174,68 @@ export default OccurrenceComponent.extend({
     );
 
     return moment.duration(
-      Math.floor(offsetX / this.get('dayWidth')) -
-      this.get('day.offset'),
-      'days'
+      Math.floor(offsetX / this.get("dayWidth")) - this.get("day.offset"),
+      "days"
     );
   },
 
-  _dragEnd: function() {
-    this.get('onUpdate')(this.get('content'), {
-      startsAt: this.get('_preview.content.startsAt'),
-      endsAt: this.get('_preview.content.endsAt')
+  _dragEnd: function () {
+    this.get("onUpdate")(this.get("content"), {
+      startsAt: this.get("_preview.content.startsAt"),
+      endsAt: this.get("_preview.content.endsAt"),
     });
 
-    this.set('isInteracting', false);
-    this.set('_calendar.occurrencePreview', null);
-    this.set('_dragVerticalOffset', null);
-    this.set('_dragTopDistance', null);
-    this.set('_dragBottomDistance', null);
+    this.set("isInteracting", false);
+    this.set("_calendar.occurrencePreview", null);
+    this.set("_dragVerticalOffset", null);
+    this.set("_dragTopDistance", null);
+    this.set("_dragBottomDistance", null);
   },
 
-  _mouseUp: function() {
-    document.documentElement.style.cursor = '';
+  _mouseUp: function () {
+    document.documentElement.style.cursor = "";
   },
 
-  _tap: function(event) {
-    this.get('onClick')(this.get('content'));
+  _tap: function (event) {
+    this.get("onClick")(this.get("content"));
     event.preventDefault();
   },
 
-  _doubleTap: function(event) {
-    this.get('onDoubleClick')(this.get('content'));
+  _doubleTap: function (event) {
+    this.get("onDoubleClick")(this.get("content"));
     event.preventDefault();
   },
 
-  _validateAndSavePreview: function(changes) {
+  _validateAndSavePreview: function (changes) {
     if (this._validatePreviewChanges(changes)) {
-      this.get('onUpdate')(this.get('_preview.content'), changes);
+      this.get("onUpdate")(this.get("_preview.content"), changes);
     }
   },
 
-  _validatePreviewChanges: function(changes) {
-    var newPreview = this.get('_preview').copy();
+  _validatePreviewChanges: function (changes) {
+    var newPreview = this.get("_preview").copy();
 
-    newPreview.get('content').setProperties(changes);
+    newPreview.get("content").setProperties(changes);
 
-    return newPreview.get('startingTime') >= newPreview.get('day.startingTime') &&
-           newPreview.get('endingTime') <= newPreview.get('day.endingTime') &&
-           newPreview.get('duration') >= this.get('computedTimeSlotDuration');
+    return (
+      newPreview.get("startingTime") >= newPreview.get("day.startingTime") &&
+      newPreview.get("endingTime") <= newPreview.get("day.endingTime") &&
+      newPreview.get("duration") >= this.get("computedTimeSlotDuration")
+    );
   },
 
-  _clamp: function(number, min, max) {
+  _clamp: function (number, min, max) {
     return Math.max(min, Math.min(number, max));
   },
 
   actions: {
-    remove: function() {
-      this.get('onRemove')(this.get('content'));
-      this.set('isInteracting', false);
+    remove: function () {
+      this.get("onRemove")(this.get("content"));
+      this.set("isInteracting", false);
     },
-    edit: function() {
-      this.get('onEdit')(this.get('content'));
-      this.set('isInteracting', false);
-    }
-  }
+    edit: function () {
+      this.get("onEdit")(this.get("content"));
+      this.set("isInteracting", false);
+    },
+  },
 });


### PR DESCRIPTION
Fix usage of this.element.getBoundingClientRect to get the correct offset of the element.